### PR TITLE
Added tests to verify headers + body are set correctly on request

### DIFF
--- a/spec/Request/HandlerSpec.php
+++ b/spec/Request/HandlerSpec.php
@@ -28,10 +28,11 @@ class HandlerSpec extends ObjectBehavior
         RequestFactoryInterface $requestFactory,
         RequestInterface $request
     ) {
-        $requestFactory->createRequest('GET', 'http://example.com/xapi/statements', array(
-            'X-Experience-API-Version' => '1.0.1',
-            'Content-Type' => 'application/json',
-        ), null)->willReturn($request);
+        $requestFactory->createRequest('GET', 'http://example.com/xapi/statements')->willReturn($request);
+        $request->withHeader('X-Experience-API-Version', '1.0.1')->willReturn($request);
+        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
+        $request->getBody()->willReturn($request);
+        $request->withBody($request)->willReturn($request);
 
         $this->createRequest('get', '/statements')->shouldReturn($request);
         $this->createRequest('GET', '/statements')->shouldReturn($request);
@@ -39,12 +40,16 @@ class HandlerSpec extends ObjectBehavior
 
     function it_returns_post_request_created_by_the_http_client(
         RequestFactoryInterface $requestFactory,
-        RequestInterface $request
+        RequestInterface $request,
+        \Psr\Http\Message\StreamInterface $stream
     ) {
-        $requestFactory->createRequest('POST', 'http://example.com/xapi/statements', array(
-            'X-Experience-API-Version' => '1.0.1',
-            'Content-Type' => 'application/json',
-        ), 'body')->willReturn($request);
+        $requestFactory->createRequest('POST', 'http://example.com/xapi/statements')->willReturn($request);
+        $request->withHeader('X-Experience-API-Version', '1.0.1')->willReturn($request);
+        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
+        $request->getBody()->willReturn($stream);
+        $stream->write('body')->willReturn($stream);
+        $stream->rewind()->willReturn($stream);
+        $request->withBody($stream)->willReturn($request);
 
         $this->createRequest('post', '/statements', array(), 'body')->shouldReturn($request);
         $this->createRequest('POST', '/statements', array(), 'body')->shouldReturn($request);
@@ -52,12 +57,16 @@ class HandlerSpec extends ObjectBehavior
 
     function it_returns_put_request_created_by_the_http_client(
         RequestFactoryInterface $requestFactory,
-        RequestInterface $request
+        RequestInterface $request,
+        \Psr\Http\Message\StreamInterface $stream
     ) {
-        $requestFactory->createRequest('PUT', 'http://example.com/xapi/statements', array(
-            'X-Experience-API-Version' => '1.0.1',
-            'Content-Type' => 'application/json',
-        ), 'body')->willReturn($request);
+        $requestFactory->createRequest('PUT', 'http://example.com/xapi/statements')->willReturn($request);
+        $request->withHeader('X-Experience-API-Version', '1.0.1')->willReturn($request);
+        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
+        $request->getBody()->willReturn($stream);
+        $stream->write('body')->willReturn($stream);
+        $stream->rewind()->willReturn($stream);
+        $request->withBody($stream)->willReturn($request);
 
         $this->createRequest('put', '/statements', array(), 'body')->shouldReturn($request);
         $this->createRequest('PUT', '/statements', array(), 'body')->shouldReturn($request);
@@ -67,10 +76,11 @@ class HandlerSpec extends ObjectBehavior
         RequestFactoryInterface $requestFactory,
         RequestInterface $request
     ) {
-        $requestFactory->createRequest('DELETE', 'http://example.com/xapi/statements', array(
-            'X-Experience-API-Version' => '1.0.1',
-            'Content-Type' => 'application/json',
-        ), null)->willReturn($request);
+        $requestFactory->createRequest('DELETE', 'http://example.com/xapi/statements')->willReturn($request);
+        $request->withHeader('X-Experience-API-Version', '1.0.1')->willReturn($request);
+        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
+        $request->getBody()->willReturn($request);
+        $request->withBody($request)->willReturn($request);
 
         $this->createRequest('delete', '/statements')->shouldReturn($request);
         $this->createRequest('DELETE', '/statements')->shouldReturn($request);

--- a/src/Request/Handler.php
+++ b/src/Request/Handler.php
@@ -53,6 +53,7 @@ final class Handler implements HandlerInterface
      */
     public function createRequest($method, $uri, array $urlParameters = array(), $body = null, array $headers = array())
     {
+
         if (!in_array(strtoupper($method), array('GET', 'POST', 'PUT', 'DELETE'))) {
             throw new \InvalidArgumentException(sprintf('"%s" is no valid HTTP method (expected one of [GET, POST, PUT, DELETE]) in an xAPI context.', $method));
         }
@@ -71,7 +72,23 @@ final class Handler implements HandlerInterface
             $headers['Content-Type'] = 'application/json';
         }
 
-        return $this->requestFactory->createRequest(strtoupper($method), $uri, $headers, $body);
+        $request = $this->requestFactory->createRequest(strtoupper($method), $uri);
+
+        // Add headers to the request
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        // Add body to the request if it exists
+        if (null !== $body) {
+            // Create a stream for the body
+            $stream = $request->getBody();
+            $stream->write($body);
+            $stream->rewind();
+            $request = $request->withBody($stream);
+        }
+
+        return $request;
     }
 
     /**

--- a/tests/Request/HandlerTest.php
+++ b/tests/Request/HandlerTest.php
@@ -1,0 +1,337 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\Client\Tests\Request;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Xabbuh\XApi\Client\Request\Handler;
+
+/**
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class HandlerTest extends TestCase
+{
+    /**
+     * @var ClientInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $httpClient;
+
+    /**
+     * @var RequestFactoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $requestFactory;
+
+    /**
+     * @var RequestInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $request;
+
+    /**
+     * @var Handler
+     */
+    private $handler;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $this->request = $this->createMock(RequestInterface::class);
+        $this->handler = new Handler($this->httpClient, $this->requestFactory, 'http://example.com/xapi', '1.0.3');
+    }
+
+    public function testCreateRequestWithGetMethod()
+    {
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with(
+                'GET',
+                'http://example.com/xapi/statements'
+            )
+            ->willReturn($this->request);
+
+        $this->request->expects($this->exactly(2))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['X-Experience-API-Version', '1.0.3'],
+                ['Content-Type', 'application/json']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->request,
+                $this->request
+            );
+
+        $request = $this->handler->createRequest('GET', '/statements');
+
+        $this->assertSame($this->request, $request);
+    }
+
+    public function testCreateRequestWithPostMethod()
+    {
+        $body = '{"id":"12345678-1234-5678-1234-567812345678"}';
+        $stream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with(
+                'POST',
+                'http://example.com/xapi/statements'
+            )
+            ->willReturn($this->request);
+
+        $this->request->expects($this->exactly(2))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['X-Experience-API-Version', '1.0.3'],
+                ['Content-Type', 'application/json']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->request,
+                $this->request
+            );
+
+        $this->request->expects($this->once())
+            ->method('getBody')
+            ->willReturn($stream);
+
+        $stream->expects($this->once())
+            ->method('write')
+            ->with($body)
+            ->willReturn(strlen($body));
+
+        $stream->expects($this->once())
+            ->method('rewind');
+
+        $this->request->expects($this->once())
+            ->method('withBody')
+            ->with($stream)
+            ->willReturn($this->request);
+
+        $request = $this->handler->createRequest('POST', '/statements', [], $body);
+
+        $this->assertSame($this->request, $request);
+    }
+
+    public function testCreateRequestWithPutMethod()
+    {
+        $body = '{"id":"12345678-1234-5678-1234-567812345678"}';
+        $stream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with(
+                'PUT',
+                'http://example.com/xapi/statements'
+            )
+            ->willReturn($this->request);
+
+        $this->request->expects($this->exactly(2))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['X-Experience-API-Version', '1.0.3'],
+                ['Content-Type', 'application/json']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->request,
+                $this->request
+            );
+
+        $this->request->expects($this->once())
+            ->method('getBody')
+            ->willReturn($stream);
+
+        $stream->expects($this->once())
+            ->method('write')
+            ->with($body)
+            ->willReturn(strlen($body));
+
+        $stream->expects($this->once())
+            ->method('rewind');
+
+        $this->request->expects($this->once())
+            ->method('withBody')
+            ->with($stream)
+            ->willReturn($this->request);
+
+        $request = $this->handler->createRequest('PUT', '/statements', [], $body);
+
+        $this->assertSame($this->request, $request);
+    }
+
+    public function testCreateRequestWithDeleteMethod()
+    {
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with(
+                'DELETE',
+                'http://example.com/xapi/statements'
+            )
+            ->willReturn($this->request);
+
+        $this->request->expects($this->exactly(2))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['X-Experience-API-Version', '1.0.3'],
+                ['Content-Type', 'application/json']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->request,
+                $this->request
+            );
+
+        $request = $this->handler->createRequest('DELETE', '/statements');
+
+        $this->assertSame($this->request, $request);
+    }
+
+    public function testCreateRequestWithUrlParameters()
+    {
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with(
+                'GET',
+                'http://example.com/xapi/statements?statementId=12345678-1234-5678-1234-567812345678&limit=10'
+            )
+            ->willReturn($this->request);
+
+        $this->request->expects($this->exactly(2))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['X-Experience-API-Version', '1.0.3'],
+                ['Content-Type', 'application/json']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->request,
+                $this->request
+            );
+
+        $request = $this->handler->createRequest(
+            'GET',
+            '/statements',
+            [
+                'statementId' => '12345678-1234-5678-1234-567812345678',
+                'limit' => 10,
+            ]
+        );
+
+        $this->assertSame($this->request, $request);
+    }
+
+    public function testCreateRequestWithCustomHeaders()
+    {
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with(
+                'GET',
+                'http://example.com/xapi/statements'
+            )
+            ->willReturn($this->request);
+
+        $this->request->expects($this->exactly(3))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['Authorization', 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+                ['X-Experience-API-Version', '1.0.3'],
+                ['Content-Type', 'application/json']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->request,
+                $this->request,
+                $this->request
+            );
+
+        $request = $this->handler->createRequest(
+            'GET',
+            '/statements',
+            [],
+            null,
+            ['Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']
+        );
+
+        $this->assertSame($this->request, $request);
+    }
+
+    public function testCreateRequestWithCustomApiVersion()
+    {
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with(
+                'GET',
+                'http://example.com/xapi/statements'
+            )
+            ->willReturn($this->request);
+
+        $this->request->expects($this->exactly(2))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['X-Experience-API-Version', '1.0.2'],
+                ['Content-Type', 'application/json']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->request,
+                $this->request
+            );
+
+        $request = $this->handler->createRequest(
+            'GET',
+            '/statements',
+            [],
+            null,
+            ['X-Experience-API-Version' => '1.0.2']
+        );
+
+        $this->assertSame($this->request, $request);
+    }
+
+    public function testCreateRequestWithCustomContentType()
+    {
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with(
+                'GET',
+                'http://example.com/xapi/statements'
+            )
+            ->willReturn($this->request);
+
+        $this->request->expects($this->exactly(2))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['Content-Type', 'application/xml'],
+                ['X-Experience-API-Version', '1.0.3']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->request,
+                $this->request
+            );
+
+        $request = $this->handler->createRequest(
+            'GET',
+            '/statements',
+            [],
+            null,
+            ['Content-Type' => 'application/xml']
+        );
+
+        $this->assertSame($this->request, $request);
+    }
+
+    public function testCreateRequestWithInvalidMethod()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            '"PATCH" is no valid HTTP method (expected one of [GET, POST, PUT, DELETE]) in an xAPI context.'
+        );
+
+        $this->handler->createRequest('PATCH', '/statements');
+    }
+}


### PR DESCRIPTION
A bug was introduced in the 1.1 where the arguments to createRequest() was modified but was not caught by tests causing the headers and body not to be included in the request.

This change addresses the PSR17Factory::createRequest() change + adds tests for it.